### PR TITLE
use Runtime Exception instead of return in main

### DIFF
--- a/MazeSolver/src/com/company/Main.java
+++ b/MazeSolver/src/com/company/Main.java
@@ -24,7 +24,7 @@ public class Main {
             if ((s.length() / 2 + 1) > numCols) {
                 System.out.println("Error in maze - must be symmetrical");
                 System.out.println("Problem String: " + s + " (length: " + (s.length() / 2 + 1) + ", expected length: " + numCols + ")");
-                return;
+                throw new RuntimeException("Invalid Maze Creation");
             }
 
             for (int colNum = 0; colNum < numCols; colNum++) {


### PR DESCRIPTION
throw a Runtime Exception if the maze cannot be instantiated due to jaggedness instead of returning from the main method.