### PR TITLE
checkmate method fixes

### DIFF
--- a/Chez/src/game/chess/BoardBuilder.java
+++ b/Chez/src/game/chess/BoardBuilder.java
@@ -38,6 +38,7 @@ public class BoardBuilder {
         gameBoard[0][4] = new King(Color.BLACK, 0, 4, gameBoard);
         gameBoard[7][4] = new King(Color.WHITE, 7, 4, gameBoard);
 
+
         return gameBoard;
 
     }

--- a/Chez/src/game/chess/King.java
+++ b/Chez/src/game/chess/King.java
@@ -129,17 +129,18 @@ class King extends Piece {
     //determine whether the King has no possible way to escape from check
     boolean isCheckmated() {
 
-        //1. see if the king can move to a space that isn't under attack.
+        //1. see if the king can move to an adjacent space that isn't under attack.
         for (int checkRow = currentRow - 1; checkRow < currentRow + 2; ++checkRow) {
             for (int checkCol = currentCol - 1; checkCol < currentCol + 2; ++checkCol) {
 
                 if (Piece.outOfBounds(checkRow) || Piece.outOfBounds(checkCol)) continue;
-                if (checkRow == 0 && checkCol == 0) continue;
+                if (checkRow == currentRow && checkCol == currentCol) continue; //self spot
 
-                if (gameBoard[checkRow][checkCol] != null) continue;
+                //own color pieces block movement
+                if (gameBoard[checkRow][checkCol] != null && gameBoard[checkRow][checkCol].COLOR == this.COLOR) continue;
 
                 if (!isSquareUnderAttack(gameBoard, checkRow, checkCol, ENEMY_COLOR)) {
-                    return false; //a spot that is in bounds, not the same spot, free, and not being attacked.
+                    return false; //a spot that is in bounds, not the same spot, free or an enemy piece, and not being attacked.
                 }
 
             }


### PR DESCRIPTION
*  fix erroneous skip of location 0,0 rather than current king starting spot
*  in king single-move checking, fix so that king attacking moves are also considered. if the king can move one square in any direction from its current position in check, and not be in check afterwards, checkmate has not occurred. 
previously this was only checked if the square was completely free, but the same logic should apply if it contains an enemy piece. this handles potential situations where multiple attacking pieces attack on the same vector and an enemy non-attacking piece is in a surrounding square. for example a king may be in check with Rooks on either end of the row, with an escape route in the form of an unable to attack enemy Bishop directly in front of it. as the king can capture this Bishop and no longer be in check, checkmate would not occur.