### PR TITLE
bugfix queen-side castling black, no load delay

### DIFF
--- a/Chez/src/game/chess/Chez.java
+++ b/Chez/src/game/chess/Chez.java
@@ -76,11 +76,11 @@ public class Chez {
             } else {
 
                 //if moves are pre-loaded, display them one-by-one after a short delay
-                try {
-                    Thread.sleep(1500);
-                } catch (InterruptedException ie) {
-                    ie.printStackTrace();
-                }
+//                try {
+//                    Thread.sleep(1500);
+//                } catch (InterruptedException ie) {
+//                    ie.printStackTrace();
+//                }
 
                 moveStr = movesQueue.poll();
 
@@ -89,97 +89,93 @@ public class Chez {
             String[] moveInfo; //stores start position of piece if provided for disambiguation [0], and the move itself [1]
 
             if (moveStr == null) continue;
+            if (moveStr.length() <= 0) continue;
 
-            if (moveStr.length() > 0) {
-                if (moveStr.charAt(0) == 'q') {
-                    break;
-                }
-                else if (moveStr.equals("resign") || moveStr.toLowerCase().charAt(0) == 's') {
-                    System.out.println(currentPlayerColor + " resigns");
-                    resigned = true;
-                    showBoard();
-                    printMovesList();
-                    break;
+            if (moveStr.charAt(0) == 'q') {
+                break;
+            }
+            else if (moveStr.equals("resign") || moveStr.toLowerCase().charAt(0) == 's') {
+                System.out.println(currentPlayerColor + " resigns");
+                resigned = true;
+                showBoard();
+                printMovesList();
+                break;
 
-                }
-                //find all possible moves for a given piece based on its board location (short name can be included but not needed)
-                else if (moveStr.toLowerCase().equals("valid") || moveStr.toLowerCase().charAt(0) == 'v') {
-                    String pieceToFindMovesFor = sc.next();
+            }
+            //find all possible moves for a given piece based on its board location (short name can be included but not needed)
+            else if (moveStr.toLowerCase().equals("valid") || moveStr.toLowerCase().charAt(0) == 'v') {
+                String pieceToFindMovesFor = sc.next();
 
-                    if (pieceToFindMovesFor.length() > 0) {
+                if (pieceToFindMovesFor.length() > 0) {
 
-                        pieceToFindMovesFor = pieceToFindMovesFor.substring(pieceToFindMovesFor.length() - 2);
-                        Integer[] findRowCol = Piece.convertAlphanumericToRowCol(pieceToFindMovesFor);
+                    pieceToFindMovesFor = pieceToFindMovesFor.substring(pieceToFindMovesFor.length() - 2);
+                    Integer[] findRowCol = Piece.convertAlphanumericToRowCol(pieceToFindMovesFor);
 
-                        if (findRowCol != null) {
-                            int findRow = findRowCol[0];
-                            int findCol = findRowCol[1];
+                    if (findRowCol != null) {
+                        int findRow = findRowCol[0];
+                        int findCol = findRowCol[1];
 
-                            if (!Piece.outOfBounds(findRow) && !Piece.outOfBounds(findCol)) {
+                        if (!Piece.outOfBounds(findRow) && !Piece.outOfBounds(findCol)) {
 
-                                Piece found = gameBoard[findRow][findCol];
+                            Piece found = gameBoard[findRow][findCol];
 
-                                if (found != null) {
+                            if (found != null) {
 
-                                    System.out.println("valid moves for " + found + ": ");
-                                    ArrayList<Integer[]> validMovesList = found.getValidMoves(lastMoveStr);
-                                    System.out.print("\t");
+                                System.out.println("valid moves for " + found + ": ");
+                                ArrayList<Integer[]> validMovesList = found.getValidMoves(lastMoveStr);
+                                System.out.print("\t");
 
-                                    for (Integer[] validRowCol : validMovesList) {
-                                        System.out.print("-");
+                                for (Integer[] validRowCol : validMovesList) {
+                                    System.out.print("-");
 
-                                        if (!(found instanceof Pawn)) {
-                                            System.out.print(found.getShortName());
-                                        }
-
-                                        Piece moveSpot = gameBoard[validRowCol[0]][validRowCol[1]];
-
-                                        //print 'x' notation if move is attack
-                                        if (moveSpot != null && moveSpot.COLOR == found.ENEMY_COLOR) {
-
-                                            if (found instanceof Pawn) {
-                                                System.out.print((char) (findCol + 'a'));
-                                            }
-
-                                            System.out.print("x");
-                                        }
-
-                                        System.out.print(Piece.convertRowColToAlphanumeric(validRowCol[0], validRowCol[1]) + " ");
+                                    if (!(found instanceof Pawn)) {
+                                        System.out.print(found.getShortName());
                                     }
 
-                                    System.out.println();
+                                    Piece moveSpot = gameBoard[validRowCol[0]][validRowCol[1]];
+
+                                    //print 'x' notation if move is attack
+                                    if (moveSpot != null && moveSpot.COLOR == found.ENEMY_COLOR) {
+
+                                        if (found instanceof Pawn) {
+                                            System.out.print((char) (findCol + 'a'));
+                                        }
+
+                                        System.out.print("x");
+                                    }
+
+                                    System.out.print(Piece.convertRowColToAlphanumeric(validRowCol[0], validRowCol[1]) + " ");
                                 }
 
+                                System.out.println();
                             }
+
                         }
-
                     }
-                    continue;
 
                 }
-                else if (moveStr.equals("load") || moveStr.toLowerCase().charAt(0) == 'l') {
-
-                    sc.nextLine();
-                    System.out.print("enter moves: ");
-                    String allGameMoves = sc.nextLine();
-
-                    movesQueue = parseFullGameNotation(allGameMoves);
-                    continue;
-
-
-                }
-                else {
-
-                    if (moveStr.length() < 2) continue;
-
-                    //sanitize move str input - for piece choice handling, rather than safety, but it also helps.
-                    moveInfo = parseNotation(moveStr);
-                    moveStr = moveInfo[1];
-                }
-            } else {
                 continue;
-            }
 
+            }
+            else if (moveStr.equals("load") || moveStr.toLowerCase().charAt(0) == 'l') {
+
+                sc.nextLine();
+                System.out.print("enter moves: ");
+                String allGameMoves = sc.nextLine();
+
+                movesQueue = parseFullGameNotation(allGameMoves);
+                continue;
+
+
+            }
+            else {
+
+                if (moveStr.length() < 2) continue;
+
+                //sanitize move str input - for piece choice handling, rather than safety, but it also helps.
+                moveInfo = parseNotation(moveStr);
+                moveStr = moveInfo[1];
+            }
 
             Piece chosenPiece = findPieceToMove(moveStr, currentPlayerColor, moveInfo[0]);
 
@@ -227,14 +223,14 @@ public class Chez {
 
             System.out.println();
 
-//            boolean attackingKing = false;
+            boolean attackingKing = false;
             String moveNotation;
 
-//            if (!Piece.outOfBounds(moveRow) && !Piece.outOfBounds(moveCol)) {
-//                if (gameBoard[moveRow][moveCol] instanceof King) {
-//                    attackingKing = true;
-//                }
-//            }
+            if (!Piece.outOfBounds(moveRow) && !Piece.outOfBounds(moveCol)) {
+                if (gameBoard[moveRow][moveCol] instanceof King) {
+                    attackingKing = true;
+                }
+            }
 
             String pieceStr = chosenPiece.getAlphanumericLoc();
 
@@ -255,6 +251,8 @@ public class Chez {
 
             if (validMove) {
 
+                ++chosenPiece.timesMoved;
+
                 if (kingMoved) {
                     int[] newKingLoc = {chosenPiece.currentRow, chosenPiece.currentCol};
 
@@ -263,6 +261,7 @@ public class Chez {
                     } else {
                         bKingLoc = newKingLoc;
                     }
+
                 }
 
                 moveNotation = moveStr;
@@ -314,18 +313,22 @@ public class Chez {
 
                 if (chosenPiece instanceof King && ((King) chosenPiece).isCastled()) {
                     moveNotation = "0-0";
+
                     if (((King) chosenPiece).isQueenSideCastled()) {
                         moveNotation += "-0";
+                        gameBoard[moveRow][moveCol + 1].timesMoved++; //increment the rook's move count
+                    } else {
+                        gameBoard[moveRow][moveCol - 1].timesMoved++;
                     }
                 }
 
                 //valid attack on king -> checkmate. NB technically impossible to capture King in real game
-                // and should be handled already through checkmate check method
-//                if (attackingKing) {
-//
-//                    checkmated = true;
+                // and should be handled already through checkmate check method.
+                if (attackingKing) {
 
-//                } else {
+                    checkmated = true;
+
+                } else {
 
                 King wKing = (King) gameBoard[wKingLoc[0]][wKingLoc[1]];
                 King bKing = (King) gameBoard[bKingLoc[0]][bKingLoc[1]];
@@ -358,7 +361,7 @@ public class Chez {
                     if (!bKingWasInCheck && currentPlayerColor == Color.WHITE) {
                         moveNotation += "+";
                     }
-//                    }
+                    }
                 }
 
                 if (checkmated) {
@@ -472,8 +475,10 @@ public class Chez {
         String alphanumericStr;
 
         //special handling for castling.
-        if (movementStr.equals("0-0") || movementStr.equals("0-0-0")) {
+        if (movementStr.equals("0-0") || movementStr.equals("O-O") || movementStr.equals("0-0-0") || movementStr.equals("O-O-O")) {
+
             int homeRow = 0;
+
             if (playerColor == Color.WHITE) {
                 homeRow = 7;
             }
@@ -858,6 +863,8 @@ public class Chez {
             //so store it too if found.
             while (!Character.isDigit(last)) {
                 destStr = destStr.substring(0, destStr.length() - 1);
+                if (destStr.length() == 0) break;
+
                 last = destStr.charAt(destStr.length() - 1);
             }
 
@@ -895,7 +902,6 @@ public class Chez {
         String[] allNotations = gameStr.split(" ");
 
         for (String move : allNotations) {
-
             if (move.length() < 2) continue;
             if (Pattern.matches("\\d+\\.", move)) continue; //remove numbers from move list.
 
@@ -956,13 +962,11 @@ public class Chez {
                     stalemate = false;
                 }
 
-
                 //move checked piece back to its original spot.
                 playerPiece.revertMove(startRow, startCol, pieceAtMoveLoc, points);
 
                 if (castledRook != null) {
                     castledRook.place(startRow, castledRookCol);
-                    --castledRook.timesMoved;
                 }
 
                 //jump out as early as possible. NB using return above won't work as pieces have to be moved back first

--- a/Chez/src/game/chess/King.java
+++ b/Chez/src/game/chess/King.java
@@ -73,6 +73,7 @@ class King extends Piece {
     //castling is TECHNICALLY a King move, even though it also involves a Rook
     private boolean checkCastling(boolean queenSide) {
 
+
         if (currentCol != 4)
             return false; //col. 4 is king's initial spot. castling requires both king & rook to not have moved
         if (timesMoved > 0) return false;
@@ -112,6 +113,7 @@ class King extends Piece {
             newRookCol = 3;
             queenSideCastled = true;
         }
+
 
         //the King is not allowed to land in a spot that results in Check (technically true of all King moves)
         if (isSquareUnderAttack(gameBoard, currentRow, newCol, ENEMY_COLOR)) {
@@ -194,12 +196,16 @@ class King extends Piece {
                 }
 
             }
-        }
+//        }
 
-        //3. if there is 1 piece only attacking the king, for the line of attack, see if any pieces can be moved into it
-        // to block the move. (check each square of the line of attack to see if it can be attacked by king's color pieces.)
-        if (attackers.size() == 1) {
-            Piece attackPiece = attackers.get(0);
+            //3. if there is 1 piece only attacking the king, for the line of attack, see if any pieces can be moved into it
+            // to block the move. (check each square of the line of attack to see if it can be attacked by king's color pieces.)
+
+//        if (attackers.size() == 1) {
+//            Piece attackPiece = attackers.get(0);
+
+            //knight can jump over pieces so cannot be blocked
+            if (attackPiece instanceof Knight) return true;
 
             int rowChange = attackPiece.currentRow < this.currentRow ? 1 : -1;
             int colChange = attackPiece.currentCol < this.currentCol ? 1 : -1;
@@ -207,7 +213,7 @@ class King extends Piece {
             int nextAttRow = attackPiece.currentRow + rowChange;
             int nextAttCol = attackPiece.currentCol + colChange;
 
-            //check one step forward. stop at King's location.
+            //check one step forward at a time, moving towards the King. stop at King's location.
             while (nextAttRow != this.currentRow && nextAttCol != this.currentCol) {
 
                 if (isSquareUnderAttack(gameBoard, nextAttRow, nextAttCol, this.COLOR)) {
@@ -223,7 +229,7 @@ class King extends Piece {
 
                     int totalDefenders = defendersWithoutPawn.size();
 
-                    //check for any pawns that can move straight forward to the current check spot
+                    //check and add any pawns that can move straight forward to the current check spot
                     int pawnPrecedingRow = COLOR == Color.BLACK ? nextAttRow - 1 : nextAttRow + 1;
 
                     if (!Piece.outOfBounds(pawnPrecedingRow) && gameBoard[pawnPrecedingRow][nextAttCol] instanceof Pawn) {
@@ -280,14 +286,14 @@ class King extends Piece {
         ArrayList<Integer[]> validMovesList = new ArrayList<>();
 
         int[][] moveOffsets = {
-                {-1,-1}, //top left direction
+                {-1, -1}, //top left direction
                 {-1, 0},
-                {-1,+1}, //top right
+                {-1, +1}, //top right
                 {0, -1}, //left
                 {0, +1}, //right
-                {+1,-1}, //bottom left
+                {+1, -1}, //bottom left
                 {+1, 0},
-                {+1,+1}, //bottom right
+                {+1, +1}, //bottom right
         };
 
         for (int[] offsetRowCol : moveOffsets) {
@@ -309,15 +315,14 @@ class King extends Piece {
 
         }
 
-            if (checkCastling(true)) {
-                Integer[] validMove = {currentRow, 2};
-                validMovesList.add(validMove);
-            }
-            if (checkCastling(false)) {
-                Integer[] validMove = {currentRow, 6};
-                validMovesList.add(validMove);
-            }
-
+        if (checkCastling(true)) {
+            Integer[] validMove = {currentRow, 2};
+            validMovesList.add(validMove);
+        }
+        if (checkCastling(false)) {
+            Integer[] validMove = {currentRow, 6};
+            validMovesList.add(validMove);
+        }
 
 
         return validMovesList;

--- a/Chez/src/game/chess/Piece.java
+++ b/Chez/src/game/chess/Piece.java
@@ -64,7 +64,7 @@ abstract class Piece {
             currentRow = row;
             currentCol = col;
             gameBoard[row][col] = this;
-            ++timesMoved;
+//            ++timesMoved;
         }
     }
 
@@ -149,6 +149,8 @@ abstract class Piece {
      * @param checkRowAndCol An Integer array containing the row and column to check in position 0 and 1 respectively.
      * @param otherTeamColor The enemy piece's color.
      * @param quickCheck Toggle immediate (short-circuit) return on discovery of any attacking piece (e.g. for determining if a King is in check).
+     * @param lastMoveStr The previous move in the game, which is necessary to check for a Pawn en passant capture as it can only occur on the move
+     *                    directly after the enemy's Pawn has moved forward two squares.
      * @return An ArrayList of all the pieces attacking that square.
      */
     static ArrayList<Piece> findAttackingPieces(Piece[][] gameBoard, Integer[] checkRowAndCol, Color otherTeamColor, boolean quickCheck, String lastMoveStr) {
@@ -367,10 +369,11 @@ abstract class Piece {
         }
 
         gameBoard[prevRow][prevCol] = this;
-        --timesMoved;
+//        --timesMoved;
 
         if (capturedPiece != null) {
             capturedPiece.captured = false;
+//            --capturedPiece.timesMoved;
             capturedPiece.currentRow = this.currentRow;
             capturedPiece.currentCol = this.currentCol;
             gameBoard[currentRow][currentCol] = capturedPiece;

--- a/Chez/src/game/chess/Rook.java
+++ b/Chez/src/game/chess/Rook.java
@@ -52,7 +52,7 @@ class Rook extends Piece {
         //update board
         place(row, col);
 
-        ++timesMoved;
+//        ++timesMoved;
         return true;
 
     }


### PR DESCRIPTION
*  change "times moved" tracking for pieces to only record moves in the game play itself and not whenever the piece was moved - e.g. at initial placement or in stalemate check methods, etc. erroneous move recording for rook which should have been re-decremented was preventing queen-side castling for black. 

move count is now only incremented for a piece when a valid move is recorded in the normal game, with castled rooks' move count being incremented there too when necessary.

*  loaded moves are again displayed instantly rather than after a delay for easier testing of specific board / game play scenarios. to be added as an option later.